### PR TITLE
Toggle the visibility of the indicator depends on the key 'show-icon-on-systray'

### DIFF
--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -48,6 +48,9 @@ public class InputMethod.Indicator : Wingpanel.Indicator {
             });
 
             layouts.updated ();
+
+            var ibus_panel_settings = new Settings ("org.freedesktop.ibus.panel");
+            ibus_panel_settings.bind ("show-icon-on-systray", this, "visible", SettingsBindFlags.DEFAULT);
         }
 
         return display_icon;


### PR DESCRIPTION
We can now switch this value from Switchboard Input Method Plug: https://github.com/ele-l10n-cjk/switchboard-plug-inputmethod/pull/11
