### PR TITLE
Indicator: Remove deprecated properties

### DIFF
--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -22,9 +22,9 @@ public class InputMethod.Indicator : Wingpanel.Indicator {
     private InputMethod.Widgets.EngineManager engines;
 
     public Indicator () {
-        Object (code_name: "input-method-indicator",
-                display_name: _("Input Method"),
-                description:_("The input method indicator"));
+        Object (
+            code_name: "input-method-indicator"
+        );
     }
 
     public override Gtk.Widget get_display_widget () {


### PR DESCRIPTION
`display_name` & `description` were deprecated in https://github.com/elementary/wingpanel/commit/86098c2059e7fa6af82f888f755aeec31d00fd31
